### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.134.0/containers/javascript-node/.devcontainer/base.Dockerfile
+ARG VARIANT="12"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+RUN sudo -u node npm install -g eslint

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.134.0/containers/javascript-node
+{
+    "name": "Node.js",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            "VARIANT": "12"
+        }
+    },
+    // Set *default* container specific settings.json values on container create.
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "dbaeumer.vscode-eslint"
+    ],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+        3000
+    ],
+    // Specifies a command that should be run after the container has been created.
+    "postCreateCommand": "yarn install",
+    // Comment out the next line to run as root instead.
+    "remoteUser": "node"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "ms-vscode.node-debug2",
+        "dbaeumer.vscode-eslint",
+        "ms-vscode-remote.remote-containers"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,30 +1,13 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Rossconf
 
-## Getting Started
+## local development
 
-First, run the development server:
+We have included devcontainer for you to get started with an completely configued and ready to go NodeJS 12 development environment. 
 
-```bash
-npm run dev
-# or
-yarn dev
-```
+In order to make use of this container you will need to use VSCode with the [remote containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+When you open the project in VSCode you will be asked to install the recommended plugins which inculde the remote containers plugin.
 
-You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
+If you are connected to the remote container you can use the `Teminal -> Run Task` option to run the `npm dev` task to start the dev server. After  you have done this you can connect to [http://localhost:3000](http://localhost:3000)
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/import?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+If you like to get a shell on the devcontainer you can start a new bash shell. This will connect you to the devcontainer. The node user has sudo access, so you can install packages in the container if you would like them. Please note, this will not persist, so you might want to make a PR againt the Dockerfile.


### PR DESCRIPTION
This PR adds a dev container to the project.

You can now connect your VSCode or Codespace to this container to get a fully set up and ready to go nodejs develop environment.

Included documentation as well, this might need some more words as we get questions on this feature.